### PR TITLE
Updated link to the website repositories

### DIFF
--- a/modules/ROOT/pages/kb/docs/contributing.adoc
+++ b/modules/ROOT/pages/kb/docs/contributing.adoc
@@ -59,7 +59,7 @@ image::kb/docs/contributing-link.png[title="Click the 'See this page in GitHub' 
 
 image::kb/docs/contributing-button.png[title="Edit button in GitHub"]
 
-If you don't have edit permissions you always can clone the link:https://github.com/apache/netbeans-website[website repository in GitHub] and edit the file in your own clone, and then submit that as a Pull Request against the main Apache NetBeans website repository.
+If you don't have edit permissions you always can clone the link:https://github.com/apache/netbeans-antora[website repositories in GitHub] and edit the file in your own clone, and then submit that as a Pull Request against the main Apache NetBeans website repository.
 
 You can also watch the following YouTube video for instructions:
 


### PR DESCRIPTION
Link was still pointing to the deprecated website repository. Updated to the current antora-website repository